### PR TITLE
change file reference format

### DIFF
--- a/modding_guide/essentials/mixintos_overrides/index.html
+++ b/modding_guide/essentials/mixintos_overrides/index.html
@@ -492,9 +492,9 @@
 
 
 <pre><code>  "overrides" : {
-     "/stonehearth/data/rigs/entities/humans/effects/my_effect.json" : "/my_mod_namespace/my_effect.json",
-     "/stonehearth/data/rigs/entities/humans/animations/female/my_anim.json": "/my_mod_namespace/animations/female/my_anim.json",
-     "/stonehearth/data/rigs/entities/humans/animations/male/my_anim.json": "/my_mod_namespace/animations/male/my_anim.json"
+     "stonehearth/data/rigs/entities/humans/effects/my_effect.json" : "file(my_overrides/my_effect.json)",
+     "stonehearth/data/rigs/entities/humans/animations/female/my_anim.json": "file(animations/female/my_anim.json)",
+     "stonehearth/data/rigs/entities/humans/animations/male/my_anim.json": "file(animations/male/my_anim.json)"
   }
 </code></pre>
 


### PR DESCRIPTION
Currently listed ways of overriding a file do not work. Proposing these changes, which work out of the box, and seem more familiar to users who are used to the `file()` syntax.